### PR TITLE
Calculate the height of the editor using the beautified JSON output.

### DIFF
--- a/src/app/directives/sidebar.js
+++ b/src/app/directives/sidebar.js
@@ -83,8 +83,8 @@
           // If the response fails because of CORS, responseText is null
           var editorHeight = 50;
 
-          if (jqXhr.responseText) {
-            var lines = jqXhr.responseText.split('\n').length;
+          if ($scope.response.body) {
+            var lines = $scope.response.body.split('\n').length;
             editorHeight = lines > 100 ? 2000 : 25*lines;
           }
 


### PR DESCRIPTION
The console beautifies the response from the backend, but calculates the height
of the editor using the original, unbeautified response body.
